### PR TITLE
Provide correct links to node-lame / added deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-kcrw
 
 Play the KCRW live stream in your Terminal. Because why not.  
-Made mostly possibe by [node-lame][NodeLame] and [node-speaker][AodeSpeaker].
+Made mostly possibe by [node-lame][NodeLame] and [node-speaker][NodeSpeaker].
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-kcrw
 
 Play the KCRW live stream in your Terminal. Because why not.  
-Made mostly possibe by [node-lame](https://github.com/TooTallNate/node-speaker) and [node-speaker](https://github.com/TooTallNate/node-speaker).
+Made mostly possibe by [node-lame][NodeLame] and [node-speaker][AodeSpeaker].
 
 ## Install
 
@@ -9,6 +9,15 @@ With [npm](https://npmjs.org) do (you may need sudo):
 
 ```
 npm install -g kcrw
+```
+
+## Dependencies
+
+On Debian/Ubuntu, the [ALSA][alsa] backend is selected by default, so be sure
+to have the `alsa.h` header file in place:
+
+``` bash
+$ sudo apt-get install libasound2-dev
 ```
 
 ## Usage
@@ -26,3 +35,7 @@ Haven't tested on Windows. Would like to add KCRW's 24/7 streams (both news & mu
 ## License
 
 MIT
+
+[NodeLame]: https://github.com/TooTallNate/node-lame
+[NodeSpeaker]: https://github.com/TooTallNate/node-speaker
+[alsa]: http://www.alsa-project.org/


### PR DESCRIPTION
node-lame was linking to node-speaker. Also, defined a dependencies section that may be required for debian systems.
